### PR TITLE
BUG: Fix incorrect output, and invalid memory access

### DIFF
--- a/src/itkSTLMeshIO.cxx
+++ b/src/itkSTLMeshIO.cxx
@@ -600,6 +600,9 @@ STLMeshIO
 
   for ( SizeValueType polygonItr = 0; polygonItr < numberOfPolygons; polygonItr++ )
     {
+    // skip cell type and number of vertices in cell
+    index += 2;
+
     const PointType & p0 = m_Points[ cellsBuffer[index++] ];
     const PointType & p1 = m_Points[ cellsBuffer[index++] ];
     const PointType & p2 = m_Points[ cellsBuffer[index++] ];


### PR DESCRIPTION
The m_Points array was incorrectly traversed. It's a mix of cellType,
numberOfVerticiesInCells, followed by index into points. The
first two are not correctly being skipped.

This issue was detected by valgrind defects.