### PR TITLE
COMP: Address override warnings.

### DIFF
--- a/include/itkSTLMeshIO.h
+++ b/include/itkSTLMeshIO.h
@@ -57,31 +57,31 @@ public:
   * \post Sets classes MeshIOBase::m_FileName variable to be FileNameToWrite
   * \return Returns true if this MeshIO can read the file specified.
   */
-  virtual bool CanReadFile(const char *FileNameToRead);
+  virtual bool CanReadFile(const char *FileNameToRead) ITK_OVERRIDE;
 
   /** Read the content of the file into a Mesh. */
   virtual void Read();
 
   /** Set the spacing and dimension information for the set filename. */
-  virtual void ReadMeshInformation();
+  virtual void ReadMeshInformation() ITK_OVERRIDE;
 
   /** Stores the point data into the memory buffer provided. */
-  virtual void ReadPoints(void *buffer);
+  virtual void ReadPoints(void *buffer) ITK_OVERRIDE;
 
   /** Stores the cell data into the memory buffer provided. */
-  virtual void ReadCells(void *buffer);
+  virtual void ReadCells(void *buffer) ITK_OVERRIDE;
 
   /** Indicates whether ReadPoints() should be called. */
-  virtual bool GetUpdatePoints() const;
+  virtual bool GetUpdatePoints() const ITK_OVERRIDE;
 
   /** Indicates whether ReadCells() should be called. */
-  virtual bool GetUpdateCells() const;
+  virtual bool GetUpdateCells() const ITK_OVERRIDE;
 
   /** STL files do not carry information in points or cells.
    * Therefore the following two methods are implemented as null
    * operations. */
-  virtual void ReadPointData( void * itkNotUsed(buffer) ) {};
-  virtual void ReadCellData( void * itkNotUsed(buffer) ) {};
+  virtual void ReadPointData( void * itkNotUsed(buffer) ) ITK_OVERRIDE {};
+  virtual void ReadCellData( void * itkNotUsed(buffer) ) ITK_OVERRIDE {};
 
   /*-------- This part of the interfaces deals with writing data. ----- */
   /** Determine if the file can be written with this MeshIO implementation.
@@ -89,13 +89,13 @@ public:
    * \post Sets classes MeshIOBase::m_FileName variable to be FileNameToWrite
    * \return Returns true if this MeshIO can write the file specified.
    */
-  virtual bool CanWriteFile(const char *FileNameToWrite);
+  virtual bool CanWriteFile(const char *FileNameToWrite) ITK_OVERRIDE;
 
   /** Write header of the STL file */
-  virtual void WriteMeshInformation();
+  virtual void WriteMeshInformation() ITK_OVERRIDE;
 
   /** Write the content of the Mesh into an STL file. */
-  virtual void Write();
+  virtual void Write() ITK_OVERRIDE;
 
   /** The STL format stores point coordinates repeatedly as part of every
    * triangle. Therefore point coordinates are writen as part of the
@@ -103,7 +103,7 @@ public:
    * Consequently, this method only performs an internal copy of the Point
    * coordinates data, than then is used in the WriteCells() method.
    */
-  virtual void WritePoints( void * buffer );
+  virtual void WritePoints( void * buffer ) ITK_OVERRIDE;
 
   /** The WriteCells() method does most of the work. It writes
    * out every triangle in the mesh. For every triangle, it
@@ -121,19 +121,19 @@ public:
    *        endfacet
    *
    */
-  virtual void WriteCells(void *buffer);
+  virtual void WriteCells(void *buffer) ITK_OVERRIDE;
 
   /** STL files do not carry information in points or cells.
    * Therefore the following two methods are implemented as null
    * operations. */
-  virtual void WritePointData( void * itkNotUsed(buffer) ) {};
-  virtual void WriteCellData( void * itkNotUsed(buffer) ) {};
+  virtual void WritePointData( void * itkNotUsed(buffer) ) ITK_OVERRIDE {};
+  virtual void WriteCellData( void * itkNotUsed(buffer) ) ITK_OVERRIDE {};
 
 protected:
   STLMeshIO();
   virtual ~STLMeshIO() {}
 
-  void PrintSelf(std::ostream & os, Indent indent) const;
+  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
   /** Templated version of write points method, that is aware of the specific
    * type used to represent the point coordinates. */


### PR DESCRIPTION
Warnings were encountered when building on Mac OSX with -std=c++11, building the IOSTL remote module.