### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkSTLMeshIO.h
+++ b/include/itkSTLMeshIO.h
@@ -38,6 +38,8 @@ namespace itk
 class IOSTL_EXPORT STLMeshIO : public MeshIOBase
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(STLMeshIO);
+
   /** Standard "Self" type alias. */
   using Self = STLMeshIO;
   using Superclass = MeshIOBase;
@@ -168,8 +170,6 @@ protected:
 
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(STLMeshIO);
-
   std::ofstream   m_OutputStream;  // output file
   std::ifstream   m_InputStream;   // input file
 

--- a/include/itkSTLMeshIOFactory.h
+++ b/include/itkSTLMeshIOFactory.h
@@ -33,6 +33,8 @@ namespace itk
 class IOSTL_EXPORT STLMeshIOFactory:public ObjectFactoryBase
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(STLMeshIOFactory);
+
   /** Standard class type alias. */
   using Self = STLMeshIOFactory;
   using Superclass = ObjectFactoryBase;
@@ -63,9 +65,6 @@ protected:
   ~STLMeshIOFactory() override;
 
   void PrintSelf(std::ostream & os, Indent indent) const override;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(STLMeshIOFactory);
 };
 } // end namespace itk
 


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.